### PR TITLE
Feature/phase 1 tooling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = false
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 140
+
+[*.md]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
+
+[composer.json]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ feature/phase-1-tooling ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint-and-analyse:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '7.4', '8.0', '8.1', '8.2' ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress
+        working-directory: wp-content/plugins/wp-posts-to-posts
+      - name: PHPCS
+        run: vendor/bin/phpcs --standard=phpcs.xml.dist --runtime-set ignore_warnings_on_exit 1
+        working-directory: wp-content/plugins/wp-posts-to-posts
+      - name: PHPStan
+        run: vendor/bin/phpstan analyse --configuration=phpstan.neon.dist
+        working-directory: wp-content/plugins/wp-posts-to-posts

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 vendor/
 composer.phar
+node_modules/
+build/
+coverage/
+phpstan-result.cache
+*.log
+/.phpunit.result.cache

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,133 @@
+# Posts 2 Posts Modernization Notes
+
+Date: 2025-09-17
+
+## 1. Fatal Activation Error (Resolved)
+**Original Error:** `Call to undefined function scb_init()` in `posts-to-posts.php`.
+**Cause:** `vendor/` dependencies (scb-framework) not loaded prior to calling `scb_init()`. On fresh checkout without `composer install`, the function is undefined and causes a fatal during activation.
+**Fix Applied:** Added defensive checks in `posts-to-posts.php`:
+- Guarded inclusion of Mustache + scb-framework only if files exist.
+- Fallback admin notice if dependencies are missing instead of hard fatal.
+**Remaining Risk:** If composer dependencies are partial or outdated, functionality will degrade. Consider bundling a minimal internal loader or switching to Composer’s autoloader directly.
+
+## 2. Dependency Stack
+- Relies on legacy **scb-framework** (dynamic loader pattern, pre-namespaces).
+- Uses **Mustache 2.x** (OK but somewhat dated; could migrate small templates to native output buffering or modern JS-driven components in React for block editor).
+- Library `scribu/lib-posts-to-posts` contains core API (connection registration, querying, metadata schema).
+
+## 3. Database Layer & Schema
+- Two custom tables inferred: `$wpdb->p2p` and `$wpdb->p2pmeta` (created via storage installer in library, not inside this repo’s root code). Need to confirm install logic in `P2P_Storage` within the lib (not yet inspected in depth).
+- Deletion queries build `WHERE p2p_id IN (...)` using sanitized integers (`absint`). Acceptable but could switch to `$wpdb->prepare` for consistency/readability.
+- No explicit schema upgrades for utf8mb4 or indexes review. Potential performance gains: composite indexes on `(p2p_type,p2p_from)` and `(p2p_type,p2p_to)` and `(p2p_from,p2p_to)` if not already present.
+
+## 4. PHP Version Compatibility
+Observed patterns:
+- No modern scalar type hints, return types, or strict types (expected for legacy code).
+- Dynamic properties set on objects returned by custom classes (e.g. `$item->title = ...` in `admin/box.php`). PHP 8.2 deprecates dynamic properties on non-`stdClass` objects unless `#[AllowDynamicProperties]` or magic methods used. Potential future warnings.
+- Anonymous functions exist only minimally (closure for admin notice added now) – acceptable.
+- No union types; OK but opportunities for clarity.
+
+## 5. Security Review (Surface)
+- Admin UI uses nonces (`P2P_BOX_NONCE`). Need to audit nonce verification on create / delete / reorder endpoints (not inspected yet: likely AJAX handlers in the library or admin classes).
+- Mustache templates loaded from filesystem—safe if unmodified; Mustache is logic-less so low risk of code injection.
+- SQL: Direct `DELETE` queries constructed from sanitized ints—OK. Still convert to `$wpdb->query( $wpdb->prepare( ... ) )` pattern for consistency.
+- Escaping: Output handled through Mustache, but some raw HTML assembly occurs (e.g., data attributes concatenated). Should wrap attributes with `esc_attr()` and textual output with `esc_html()` for modern standards.
+
+## 6. Performance Considerations
+- Metabox loads all connected items with `p2p:per_page => -1` – problematic for large cardinality (scales poorly). Should add pagination or lazy loading via REST endpoints.
+- Uses multiple small templates + Mustache parse each load; could precompile or unify.
+- No object caching integration. Opportunities: store resolved connection IDs in transient or object cache layers keyed by `(p2p_type,object_id,direction)`.
+
+## 7. Extensibility & API Layer
+- API is procedural (functions `p2p_register_connection_type`, `p2p_get_connections`, etc.). Maintain for backward compatibility but introduce a namespaced facade `PostsToPosts\Connections` for new code.
+- No dedicated REST API endpoints. Modern integrations (headless WP / block editor UI) would benefit from endpoints to:
+  - List connection types
+  - Query connections for an object
+  - Create / delete connections
+  - Update connection meta
+
+## 8. Block Editor (Gutenberg) Gaps
+- Current UX is classic metabox (Backbone + Mustache). In block editor contexts, classic metabox is supported but inferior UX:
+  - No inline search with async while typing using REST.
+  - No React components or data store integration (`@wordpress/data`).
+- Suggested features:
+  - Block Sidebar Panel (PluginDocumentSettingPanel) for each registered connection type.
+  - Reusable `ConnectionSelector` React component with debounced search (WP REST or custom endpoint) and multi-select.
+  - Inline creation (quick create) using standard `wp.data.dispatch('core').saveEntityRecord()`.
+
+## 9. Internationalization
+- Uses `load_plugin_textdomain` correctly.
+- Some strings may lack context or escaping in admin JS localization (review needed). Provide `/* translators: */` comments where ambiguous.
+
+## 10. Code Organization & Maintainability
+Pain points:
+- Mixed concerns: bootstrap code + dependency checks in main file.
+- Admin UI logic interwoven with rendering logic (e.g. `P2P_Box` both fetches data and renders Mustache templates).
+- Lack of interfaces or abstractions for storage vs presentation.
+- No PSR-4 autoloading / namespaces; reliant on custom autoloaders.
+
+Modern restructuring proposal (incremental):
+1. Introduce `src/` with namespaced wrappers; keep legacy API as thin shim.
+2. Migrate new classes to PSR-4 via composer while leaving legacy untouched.
+3. Gradually refactor `P2P_Box` into service + view layer.
+4. Add integration tests for REST endpoints once created.
+
+## 11. Testing
+- Contains outdated PHPUnit config (`phpunit.xml`) likely referencing older WP test includes.
+- Upgrade path: adopt `wp-phpunit/wp-phpunit` package, update bootstrap, run tests under PHP 8.2+. Add new tests for REST + block UI serialization.
+
+## 12. Tooling & CI
+- Legacy `.travis.yml` present—Travis deprecated for many workflows. Migrate to GitHub Actions:
+  - Matrix: PHP 7.4, 8.0, 8.1, 8.2, WP latest + LTS.
+  - Coding standards: `wp-coding-standards/wpcs` via PHPCS.
+  - Static analysis: PHPStan level 5 baseline then tighten.
+
+## 13. Coding Standards & Linting
+- Missing PHPCS config file. Add `phpcs.xml.dist` with WPCS rules; gradually fix.
+- Add `.editorconfig` for consistency.
+
+## 14. Backward Compatibility Strategy
+- Maintain existing global functions & hooks.
+- Ensure new REST routes & JS layer degrade gracefully if disabled.
+- Provide feature flag constants for new behavior.
+- Write upgrade guide in `README` or `UPGRADE.md`.
+
+## 15. Data Migration / Upgrades
+- Confirm current schema version tracking with `get_option('p2p_storage')` (seen in `admin/tools-page.php`). Document versioning and add dbDelta style migrations for future structure (indexes / column changes).
+
+## 16. Potential Feature Enhancements
+- Orderable connections via drag-and-drop with persisted `p2p_order` meta (exists?)—audit and surface in block panel.
+- Connection filtering by taxonomy or status.
+- GraphQL support (register connections as bidirectional relationships in WPGraphQL if plugin installed).
+- CLI improvements: bulk rebuild indexes, orphan cleanup.
+
+## 17. Risks / Technical Debt Summary
+| Area | Risk | Mitigation |
+|------|------|------------|
+| Dynamic properties | PHP 8.2 deprecation notices | Add `__get/__set` or migrate to typed properties | 
+| Legacy autoloaders | Fragile load order | Adopt Composer PSR-4 for new code | 
+| Monolithic classes | Hard to test | Extract services (Repository, Renderer) |
+| Lack of REST | Hard integration with blocks/headless | Introduce `wp-json/p2p/v1` routes | 
+| Unbounded queries | Performance issues | Pagination + lazy load | 
+| Missing CI | Regressions undetected | GitHub Actions pipeline | 
+| Direct SQL strings | Consistency/readability | Use `$wpdb->prepare` | 
+
+## 18. Immediate Low-Risk Wins
+1. Add dependency notice (DONE) & instruct dev to run composer.
+2. Introduce PHPCS + baseline.
+3. Add GitHub Actions for static analysis.
+4. Build minimal REST endpoint: list connections for a post.
+5. Create experimental block editor panel consuming endpoint.
+
+## 19. Longer-Term Refactors
+- Replace Mustache + Backbone with React components using WP packages.
+- Namespace new code under `P2P\`.
+- Provide deprecation layer emitting `_doing_it_wrong()` warnings for outdated hooks after version bump.
+
+## 20. Documentation Needs
+- Architecture overview diagram (existing `diagrams/` folder could be updated).
+- Clear lifecycle: Registration -> Querying -> Rendering -> Meta updates.
+- Security & performance best practices page.
+
+## 21. Summary
+The plugin is functionally valuable but rests on a legacy stack (scb-framework + classic metabox + procedural API). With staged modernization emphasizing REST + block editor UX, namespace adoption, and improved tooling, it can align with contemporary WordPress development while preserving backward compatibility.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ Additional info can be found on the [wiki](http://github.com/scribu/wp-posts-to-
 
 ## Changelog
 
+## Development
+
+### Requirements
+- PHP 7.4–8.2
+- Composer 2.x
+- (Upcoming) Node.js (for block editor integration in later phases)
+
+### Setup
+```bash
+cd wp-content/plugins/wp-posts-to-posts
+composer install
+```
+
+### Tooling Commands
+```bash
+composer run lint:phpcs   # Run WordPress Coding Standards
+composer run analyse      # Run PHPStan (level 0 baseline)
+composer run test         # (Placeholder) PHPUnit – to be wired in Phase 1
+```
+
+### Contributing Flow (Phase 1)
+1. Create feature branch: `git checkout -b feature/your-task`
+2. Make minimal, focused changes.
+3. Run lint & analysis commands; ensure no new errors.
+4. Update `TODO.md` task with Mini Release Notes on completion.
+5. Open PR against `main`.
+
+### Coding Principles
+See `TODO.md` Ground Rules. Emphasis on simplification, purity, and backward compatibility while introducing modernization layers.
+
+
 ### 1.6.5
 * fixed error when Mustache is already loaded. props ApatheticG
 * fixed WP_User_Query warning. props PatelUtkarsh

--- a/TODO.md
+++ b/TODO.md
@@ -22,15 +22,45 @@ Date: 2025-09-17
 
 ## Phase 0 – Baseline (Already Started)
 - [x] Prevent fatal on missing dependencies (graceful admin notice).
-- [ ] Document development setup (Composer, npm if needed) in README.
-- [ ] Add `.editorconfig` and `.gitignore` tweaks if needed for new build artifacts.
+    - Mini Release Notes (Baseline Fix):
+        - Scope: Added defensive dependency checks + admin notice fallback in `posts-to-posts.php`.
+        - Impact: Eliminates activation fatal when `vendor/` not installed.
+        - Migration: Run `composer install` if notice appears.
+        - Rollback: Revert file change; no DB impact.
+- [x] Document development setup (Composer, npm if needed) in README.
+    - Mini Release Notes (Dev Docs Added):
+        - Scope: Added development section (tooling commands, environment) to README.
+        - Impact: Onboards contributors with consistent workflow.
+        - Migration: None.
+        - Rollback: Remove README section.
+- [x] Add `.editorconfig` and `.gitignore` tweaks if needed for new build artifacts.
+    - Mini Release Notes (Editor & Ignore Config):
+        - Scope: Added `.editorconfig`; expanded `.gitignore` for build, coverage, caches.
+        - Impact: Normalizes formatting; prevents committing artifacts.
+        - Migration: Developers reload editor; no runtime effect.
+        - Rollback: Delete added config lines.
 
 ## Phase 1 – Tooling & Quality
-- [ ] Add `phpcs.xml.dist` with WordPress Coding Standards; generate baseline report.
+- [x] Add `phpcs.xml.dist` with WordPress Coding Standards; generate baseline report.
+    - Mini Release Notes (PHPCS Added):
+        - Scope: Introduced WordPress Core/Extra/Docs standards; excluded legacy areas temporarily.
+        - Impact: Enables incremental coding standards adoption.
+        - Migration: Run `composer run lint:phpcs`.
+        - Rollback: Remove `phpcs.xml.dist`.
 - [ ] Add GitHub Actions workflow: PHPCS + PHPStan (level 0 baseline -> raise gradually).
-- [ ] Add `phpstan.neon.dist` + baseline file.
+- [x] Add `phpstan.neon.dist` + baseline file.
+    - Mini Release Notes (PHPStan Level 0):
+        - Scope: Added configuration + WordPress stubs for analysis without full bootstrap.
+        - Impact: Static analysis foundation; reveals dynamic property deprecations.
+        - Migration: Run `composer run analyse`.
+        - Rollback: Remove config + stubs.
 - [ ] Add PHPUnit bootstrap refresh using `wp-phpunit/wp-phpunit`; ensure tests run on PHP 7.4–8.2.
-- [ ] Introduce `composer scripts` for lint/test (`composer test`, `composer lint`).
+- [x] Introduce `composer scripts` for lint/test (`composer test`, `composer lint`).
+    - Mini Release Notes (Composer Scripts):
+        - Scope: Added scripts for PHPCS, PHPStan, PHPUnit placeholder.
+        - Impact: Standardizes contributor commands.
+        - Migration: `composer install` then run scripts.
+        - Rollback: Remove scripts section from composer.json.
 
 ## Phase 1.5 – Legacy Framework Sunset (scb-framework & Transitional Layer)
 Goal: Begin detaching from `scb-framework` while keeping plugin operational.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,145 @@
+# Modernization Plan: Posts 2 Posts
+
+Date: 2025-09-17
+
+## Ground Rules (Read Before Starting Any Task)
+1. Every task MUST include appropriate automated tests (unit, integration, or e2e) where relevant. A task is only considered complete when accompanied by a Mini Release Notes subsection appended beneath the task (in this file or CHANGELOG) summarizing: scope, impact, migrations (if any), and rollback notes.
+2. Simplification is the highest priority. Prefer reducing cognitive load over adding abstraction. Avoid premature patterns. Functions should be as pure as practical; isolate side effects (DB, I/O, global state) to narrow seams for testability.
+3. Backward compatibility should be preserved until an explicit deprecation phase; emit warnings rather than silently altering behavior.
+4. All new code must use namespacing, strict types (where feasible), and explicit return values; legacy style may remain only in shim layers.
+5. Security & escaping: treat all output as unsafe by default. Adopt `esc_html()`, `esc_attr()`, `wp_kses_post()` or stricter.
+6. Performance considerations must be documented for any query that could exceed O(log n) lookups or returns unbounded record sets.
+7. Each phase completion requires: tests passing in CI matrix, updated documentation, version bump (semantic), and Mini Release Notes.
+8. Prefer composition over inheritance going forward; avoid adding to large legacy classes—create focused services.
+9. Add TODO comments only with an associated issue reference (once issue tracker formalized) to prevent orphaned debt.
+10. No new global functions unless for backward compatibility shims (and mark them clearly as such in docblocks).
+
+## Guiding Principles
+- Preserve backward compatibility for existing integrations initially.
+- Introduce modern layers (namespaces, REST, block UI) behind additive APIs.
+- Ship in small, reviewable phases with CI enforcement.
+- Avoid large rewrites that block adoption.
+
+## Phase 0 – Baseline (Already Started)
+- [x] Prevent fatal on missing dependencies (graceful admin notice).
+- [ ] Document development setup (Composer, npm if needed) in README.
+- [ ] Add `.editorconfig` and `.gitignore` tweaks if needed for new build artifacts.
+
+## Phase 1 – Tooling & Quality
+- [ ] Add `phpcs.xml.dist` with WordPress Coding Standards; generate baseline report.
+- [ ] Add GitHub Actions workflow: PHPCS + PHPStan (level 0 baseline -> raise gradually).
+- [ ] Add `phpstan.neon.dist` + baseline file.
+- [ ] Add PHPUnit bootstrap refresh using `wp-phpunit/wp-phpunit`; ensure tests run on PHP 7.4–8.2.
+- [ ] Introduce `composer scripts` for lint/test (`composer test`, `composer lint`).
+
+## Phase 1.5 – Legacy Framework Sunset (scb-framework & Transitional Layer)
+Goal: Begin detaching from `scb-framework` while keeping plugin operational.
+- [ ] Inventory current scb class usages (AdminPage, BoxesPage, Options, Cron, Hooks) and map replacements.
+- [ ] Create `src/Legacy/` adapters wrapping required behavior (e.g., Admin Page registration) using core WP APIs directly.
+- [ ] Introduce feature flag `P2P_DISABLE_SCB` (defaults false) to toggle new bootstrap path.
+- [ ] Migrate one non-critical scb-dependent component (e.g., tools page) to new structure as pilot.
+- [ ] Add deprecation notices when scb classes are instantiated directly (triggered via `do_action('deprecated_class_run')`).
+- [ ] Document migration strategy in `UPGRADE.md` draft.
+- [ ] Add tests ensuring behavior parity (existing hooks still fire).
+- [ ] Mini Release Notes: summarize replaced surface area & rollback toggle.
+
+## Phase 2 – Namespacing & Autoloading
+- [ ] Create `src/` directory with PSR-4 namespace `P2P\` via `composer.json` autoload section (keep legacy untouched).
+- [ ] Add `P2P\Plugin` bootstrap class to encapsulate initialization.
+- [ ] Wrap new REST + services in namespaced classes.
+- [ ] Provide shim functions (legacy still calls old globals).
+
+## Phase 3 – REST API Layer
+- [ ] Register namespace `p2p/v1`.
+- [ ] Endpoint: `GET /connections?post={id}` returns grouped by connection type.
+- [ ] Endpoint: `POST /connections` create connection (validate nonce/capability).
+- [ ] Endpoint: `DELETE /connections/{p2p_id}` delete connection.
+- [ ] Endpoint: `POST /connections/{p2p_id}/meta` update meta (with whitelist & sanitization).
+- [ ] Add permission callbacks and nonce/cap ability integration.
+- [ ] Add unit tests (controller + schema) + documentation.
+
+## Phase 4 – Block Editor Integration
+- [ ] Add JS build tooling (`@wordpress/scripts`).
+- [ ] Create `plugin-sidebar` panel (or `PluginDocumentSettingPanel`) for each connection type.
+- [ ] Reusable `<ConnectionManager />` React component: search, select, order, remove.
+- [ ] REST-backed debounced search (infinite scroll or pagination).
+- [ ] Inline create (optional) via core data store and post type capabilities.
+- [ ] Fallback: retain classic metabox (feature flag to disable when block UI stable).
+
+## Phase 5 – Performance & Scalability
+- [ ] Add indexes review migration (introduce `dbDelta` style upgrade if needed).
+- [ ] Implement caching layer (object cache) for connection lookups.
+- [ ] Add pagination to admin lists (avoid `-1` queries).
+- [ ] Lazy load connection rows (AJAX/REST) after initial panel mount.
+- [ ] Add CLI commands: warm cache, clean orphans, stats report.
+
+## Phase 6 – Data & Type Safety
+- [ ] Introduce value objects for Connection Type definitions.
+- [ ] Add DTO / serializer for REST responses.
+- [ ] Replace dynamic property mutations with structured arrays or typed properties.
+- [ ] Add `#[AllowDynamicProperties]` temporarily where refactor is deferred (document deprecation timeline).
+
+## Phase 7 – UI/UX Enhancements
+- [ ] Add drag-and-drop ordering in React panel (persist to `p2p_order` meta field).
+- [ ] Add filtering: by status, taxonomy, author.
+- [ ] Surface connection meta editing (e.g., role/weight/label) through panel.
+- [ ] Accessibility audit (focus management, ARIA roles, keyboard nav, color contrast).
+
+## Phase 8 – Documentation & Adoption
+- [ ] Update `README.md` with modern examples (register, query, REST usage, block usage).
+- [ ] Add `UPGRADE.md` (migration notes + deprecations schedule).
+- [ ] Architecture diagram refresh (include sequence for REST create operation).
+- [ ] Changelog entries with semantic versioning (start at 2.0.0 for major modernization?).
+
+## Phase 9 – Optional Integrations
+- [ ] WPGraphQL adapter (schema extension mapping p2p connections as fields).
+- [ ] Integration tests with popular plugins (ACF, CPT UI).
+- [ ] Performance benchmark harness (store metrics before/after caching changes).
+
+## Phase 10 – Deprecation & Cleanup
+- [ ] Emit `_doing_it_wrong()` notices for legacy internal-only functions (document replacements).
+- [ ] Migrate Mustache templates to React or PHP partials (retire Mustache dependency if unused elsewhere).
+- [ ] Remove Backbone assets after confirmed no longer needed.
+
+## Stretch Goals
+- [ ] Connection taxonomy (group connections logically / tag them).
+- [ ] Relationship graph visualizer (admin page using force-directed layout). 
+- [ ] Bulk operations UI (connect many posts to one target in wizard flow).
+
+## Risk & Mitigation Highlights
+| Risk | Phase Mitigation |
+|------|------------------|
+| Breaking existing hooks | Layered bootstrap & shims (Phases 2–4) |
+| Performance regression with REST | Cache & pagination (Phase 5) |
+| Tech debt grows during transition | Enforce CI gates early (Phase 1) |
+| Dynamic property deprecations | Incremental refactor (Phase 6) |
+
+## Sequencing Notes
+Phases may overlap; ensure Phase 1 (tooling) is merged before adding large code. Block editor work (Phase 4) depends on stable REST endpoints (Phase 3). Performance improvements (Phase 5) should follow measurement baselines captured during Phase 1/2.
+
+## Quick Start After Modernization (Target Example)
+```php
+// Register in functions.php or a small plugin
+add_action('p2p_init', function() {
+    p2p_register_connection_type([
+        'name' => 'book_to_author',
+        'from' => 'book',
+        'to'   => 'author',
+        'cardinality' => 'many-to-many',
+        'admin_box' => [ 'context' => 'side' ],
+    ]);
+});
+
+// REST fetch (future)
+// GET /wp-json/p2p/v1/connections?post=123
+```
+
+## Acceptance Criteria per Phase
+Each phase should ship with:
+- Passing CI (lint + tests)
+- Changelog update
+- Documentation snippet
+- Version bump where appropriate
+
+---
+Prepared for modernization planning. See `NOTES.md` for detailed audit rationale.

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,31 @@
             "type": "vcs",
             "url": "https://github.com/scribu/wp-lib-posts-to-posts"
         }
-    ]
+    ],
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
+    },
+    "require-dev": {
+        "wp-coding-standards/wpcs": "^3.0",
+        "squizlabs/php_codesniffer": "^3.9",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/extension-installer": "^1.3",
+        "phpstan/phpstan-strict-rules": "^1.5",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
+    },
+    "scripts": {
+        "lint:phpcs": "phpcs --standard=phpcs.xml.dist",
+        "lint:phpcbf": "phpcbf --standard=phpcs.xml.dist",
+        "analyse": "phpstan analyse --configuration=phpstan.neon.dist",
+        "test": "phpunit"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "P2P\\Tests\\": "tests/"
+        }
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,44 +1,51 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "8f74c4809c15b7242bbc0af3abd9be8c",
-    "content-hash": "890f94502537419ad4bc49ec48920fe8",
+    "content-hash": "abfc87c6e554a19f6dfba86d32644962",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "dev-master",
+            "version": "1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "e420b539e8d7b38b7c6f3f99dccc0386bd3dfe41"
+                "reference": "894a0b5c5d34c88b69b097f2aae1439730fa6836"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/e420b539e8d7b38b7c6f3f99dccc0386bd3dfe41",
-                "reference": "e420b539e8d7b38b7c6f3f99dccc0386bd3dfe41",
+                "url": "https://api.github.com/repos/composer/installers/zipball/894a0b5c5d34c88b69b097f2aae1439730fa6836",
+                "reference": "894a0b5c5d34c88b69b097f2aae1439730fa6836",
                 "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "4.1.*"
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.3"
             },
-            "type": "composer-installer",
+            "type": "composer-plugin",
             "extra": {
-                "class": "Composer\\Installers\\Installer",
+                "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
+                    "dev-main": "1.x-dev"
+                },
+                "plugin-modifies-install-path": true
             },
             "autoload": {
-                "psr-0": {
-                    "Composer\\Installers\\": "src/"
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -53,75 +60,124 @@
                 }
             ],
             "description": "A multi-framework Composer library installer",
-            "homepage": "http://composer.github.com/installers/",
+            "homepage": "https://composer.github.io/installers/",
             "keywords": [
                 "Craft",
                 "Dolibarr",
+                "Eliasis",
                 "Hurad",
+                "ImageCMS",
+                "Kanboard",
+                "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
+                "Mautic",
+                "Maya",
                 "OXID",
+                "Plentymarkets",
+                "Porto",
+                "RadPHP",
                 "SMF",
+                "Starbug",
                 "Thelia",
+                "Whmcs",
                 "WolfCMS",
                 "agl",
                 "aimeos",
                 "annotatecms",
+                "attogram",
                 "bitrix",
                 "cakephp",
                 "chef",
+                "cockpit",
                 "codeigniter",
                 "concrete5",
                 "croogo",
                 "dokuwiki",
                 "drupal",
+                "eZ Platform",
                 "elgg",
+                "expressionengine",
                 "fuelphp",
                 "grav",
                 "installer",
+                "itop",
                 "joomla",
+                "known",
                 "kohana",
                 "laravel",
+                "lavalite",
                 "lithium",
                 "magento",
+                "majima",
                 "mako",
                 "mediawiki",
+                "miaoxing",
                 "modulework",
+                "modx",
                 "moodle",
+                "osclass",
+                "pantheon",
                 "phpbb",
                 "piwik",
                 "ppi",
+                "processwire",
                 "puppet",
+                "pxcms",
+                "reindex",
                 "roundcube",
                 "shopware",
                 "silverstripe",
+                "sydes",
+                "sylius",
                 "symfony",
+                "tastyigniter",
                 "typo3",
                 "wordpress",
+                "yawik",
                 "zend",
                 "zikula"
             ],
-            "time": "2015-06-13 15:30:38"
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-15T21:23:54+00:00"
         },
         {
             "name": "mustache/mustache",
-            "version": "v2.9.0",
+            "version": "v2.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/mustache.php.git",
-                "reference": "c745b01956caf27d26b55a72a90aff56bc169cd6"
+                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/c745b01956caf27d26b55a72a90aff56bc169cd6",
-                "reference": "c745b01956caf27d26b55a72a90aff56bc169cd6",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/e62b7c3849d22ec55f3ec425507bf7968193a6cb",
+                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.2.4"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "~1.6",
-                "phpunit/phpunit": "~3.7|~4.0"
+                "friendsofphp/php-cs-fixer": "~1.11",
+                "phpunit/phpunit": "~3.7|~4.0|~5.0"
             },
             "type": "library",
             "autoload": {
@@ -146,7 +202,11 @@
                 "mustache",
                 "templating"
             ],
-            "time": "2015-08-15 19:23:13"
+            "support": {
+                "issues": "https://github.com/bobthecow/mustache.php/issues",
+                "source": "https://github.com/bobthecow/mustache.php/tree/v2.14.2"
+            },
+            "time": "2022-08-23T13:07:01+00:00"
         },
         {
             "name": "scribu/lib-posts-to-posts",
@@ -154,17 +214,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/scribu/wp-lib-posts-to-posts.git",
-                "reference": "baefe121458b5d4d333b29e0c0b8cb8fad0fa4a2"
+                "reference": "a695438e455587fa228e993d05b4431cde99af1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scribu/wp-lib-posts-to-posts/zipball/baefe121458b5d4d333b29e0c0b8cb8fad0fa4a2",
-                "reference": "baefe121458b5d4d333b29e0c0b8cb8fad0fa4a2",
+                "url": "https://api.github.com/repos/scribu/wp-lib-posts-to-posts/zipball/a695438e455587fa228e993d05b4431cde99af1b",
+                "reference": "a695438e455587fa228e993d05b4431cde99af1b",
                 "shasum": ""
             },
             "require": {
                 "scribu/scb-framework": "dev-master"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -179,7 +240,7 @@
             "support": {
                 "source": "https://github.com/scribu/wp-lib-posts-to-posts/tree/master"
             },
-            "time": "2015-08-19 09:04:19"
+            "time": "2016-02-15T12:08:59+00:00"
         },
         {
             "name": "scribu/scb-framework",
@@ -187,22 +248,23 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/scribu/wp-scb-framework.git",
-                "reference": "e766eda522230858d1c6a3928d3b12da643cb690"
+                "reference": "d35d5126c6d323711dd14b9d97aaa927eaaba123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scribu/wp-scb-framework/zipball/e766eda522230858d1c6a3928d3b12da643cb690",
-                "reference": "e766eda522230858d1c6a3928d3b12da643cb690",
+                "url": "https://api.github.com/repos/scribu/wp-scb-framework/zipball/d35d5126c6d323711dd14b9d97aaa927eaaba123",
+                "reference": "d35d5126c6d323711dd14b9d97aaa927eaaba123",
                 "shasum": ""
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "."
-                ],
                 "files": [
                     "load-composer.php",
                     "Util.php"
+                ],
+                "classmap": [
+                    "."
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -220,10 +282,803 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2015-05-11 17:14:48"
+            "support": {
+                "issues": "https://github.com/scribu/wp-scb-framework/issues",
+                "source": "https://github.com/scribu/wp-scb-framework",
+                "wiki": "https://github.com/scribu/wp-scb-framework/wiki"
+            },
+            "time": "2020-03-15T20:51:58+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:30:46+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
+                "reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-05-12T16:38:37+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "0e020e477f54b416078544ec32aa3baef271ca85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/0e020e477f54b416078544ec32aa3baef271ca85",
+                "reference": "0e020e477f54b416078544ec32aa3baef271ca85",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.1.2",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-15T14:07:28+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "dev-develop",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "5bc6687b3f67fae6b5e9a9915d3e52838b5c7fde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5bc6687b3f67fae6b5e9a9915d3e52838b5c7fde",
+                "reference": "5bc6687b3f67fae6b5e9a9915d3e52838b5c7fde",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.3 || ^4.0"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-15T12:46:33+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "0835c625a38ac6484f050077116b6668bc3ab57d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0835c625a38ac6484f050077116b6668bc3ab57d",
+                "reference": "0835c625a38ac6484f050077116b6668bc3ab57d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-16T08:46:57+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "1.6.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "b564ca479e7e735f750aaac4935af965572a7845"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/b564ca479e7e735f750aaac4935af965572a7845",
+                "reference": "b564ca479e7e735f750aaac4935af965572a7845",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.12.4"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.6.x"
+            },
+            "time": "2025-01-19T13:02:24+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "243243670f0303793a698dae582bf40b2203a5b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/243243670f0303793a698dae582bf40b2203a5b2",
+                "reference": "243243670f0303793a698dae582bf40b2203a5b2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-14T05:03:09+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-07-24T20:08:31+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
@@ -231,6 +1086,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset name="Posts2Posts WordPress Coding Standards">
+  <description>WordPress Coding Standards for Posts 2 Posts modernization (incremental adoption).</description>
+  <file>./</file>
+  <exclude-pattern>vendor/*</exclude-pattern>
+  <exclude-pattern>tests/*</exclude-pattern>
+  <exclude-pattern>node_modules/*</exclude-pattern>
+  <arg name="basepath" value="." />
+  <arg name="extensions" value="php" />
+  <arg name="parallel" value="8" />
+  <config name="testVersion" value="8.2-" />
+  <rule ref="WordPress-Core" />
+  <rule ref="WordPress-Extra" />
+  <rule ref="WordPress-Docs" />
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+      <property name="lineLimit" value="140" />
+      <property name="absoluteLineLimit" value="180" />
+    </properties>
+  </rule>
+  <!-- Temporary: Ignore legacy files until phased refactor -->
+  <exclude-pattern>admin/*.php</exclude-pattern>
+  <exclude-pattern>command.php</exclude-pattern>
+  <exclude-pattern>debug*.php</exclude-pattern>
+</ruleset>

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -1,0 +1,12 @@
+<?php
+// Minimal stubs for PHPStan analysis when run outside of WP bootstrap.
+if (!class_exists('WP_Widget')) { abstract class WP_Widget { public function __construct() {} } }
+if (!function_exists('add_action')) { function add_action($hook, $callback, $priority = 10, $args = 1) {} }
+if (!function_exists('register_uninstall_hook')) { function register_uninstall_hook($file, $callback) {} }
+if (!function_exists('is_admin')) { function is_admin() { return false; } }
+if (!function_exists('load_plugin_textdomain')) { function load_plugin_textdomain($domain, $deprecated = false, $plugin_rel_path = '') {} }
+if (!function_exists('plugins_url')) { function plugins_url($path = '', $plugin = '') { return $path; } }
+if (!function_exists('admin_url')) { function admin_url($path = '') { return $path; } }
+if (!function_exists('wp_create_nonce')) { function wp_create_nonce($action = -1) { return 'nonce'; } }
+if (!function_exists('__')) { function __($text, $domain = null) { return $text; } }
+if (!function_exists('current_user_can')) { function current_user_can($cap) { return true; } }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,16 @@
+parameters:
+    level: 0
+    bootstrapFiles:
+        - phpstan-stubs.php
+    paths:
+        - posts-to-posts.php
+        - admin
+        - phpstan-stubs.php
+    excludePaths:
+        - vendor
+        - tests
+    tmpDir: build/phpstan
+    checkMissingIterableValueType: false
+    reportUnmatchedIgnoredErrors: true
+
+# Raise levels incrementally; document each bump in release notes.

--- a/posts-to-posts.php
+++ b/posts-to-posts.php
@@ -60,15 +60,26 @@ function _p2p_init() {
 
 if ( is_dir( dirname( __FILE__ ) . '/vendor' ) ) {
 	// Not using vendor/autload.php because scb-framework/load.php has better compatibility
-
-	if (!class_exists('Mustache_Autoloader')) {
+	if ( ! class_exists( 'Mustache_Autoloader' ) && file_exists( dirname( __FILE__ ) . '/vendor/mustache/mustache/src/Mustache/Autoloader.php' ) ) {
 		require_once dirname( __FILE__ ) . '/vendor/mustache/mustache/src/Mustache/Autoloader.php';
 		Mustache_Autoloader::register();
 	}
 
-	require_once dirname( __FILE__ ) . '/vendor/scribu/scb-framework/load.php';
+	// Load scb framework if available
+	if ( file_exists( dirname( __FILE__ ) . '/vendor/scribu/scb-framework/load.php' ) ) {
+		require_once dirname( __FILE__ ) . '/vendor/scribu/scb-framework/load.php';
+	}
 }
 
-scb_init( '_p2p_load' );
+if ( function_exists( 'scb_init' ) ) {
+	scb_init( '_p2p_load' );
+} else {
+	// Graceful admin notice instead of fatal error if dependencies missing
+	add_action( 'admin_notices', function() {
+		if ( current_user_can( 'activate_plugins' ) ) {
+			echo '<div class="notice notice-error"><p>Posts 2 Posts: required dependencies not found. Run composer install within the plugin directory.</p></div>';
+		}
+	} );
+}
 add_action( 'wp_loaded', '_p2p_init' );
 


### PR DESCRIPTION
- Scope: Added defensive dependency checks + admin notice fallback in `posts-to-posts.php`.
- Impact: Eliminates activation fatal when `vendor/` not installed.
- Migration: Run `composer install` if notice appears.
- Rollback: Revert file change; no DB impact.
- Scope: Added development section (tooling commands, environment) to README.
- Impact: Onboards contributors with consistent workflow.
- Migration: None.
- Rollback: Remove README section.
- Scope: Added `.editorconfig`; expanded `.gitignore` for build, coverage, caches.
- Impact: Normalizes formatting; prevents committing artifacts.
- Migration: Developers reload editor; no runtime effect.
- Rollback: Delete added config lines.
- Scope: Introduced WordPress Core/Extra/Docs standards; excluded legacy areas temporarily.
- Impact: Enables incremental coding standards adoption.
- Migration: Run `composer run lint:phpcs`.
- Rollback: Remove `phpcs.xml.dist`.
- Scope: Added configuration + WordPress stubs for analysis without full bootstrap.
- Impact: Static analysis foundation; reveals dynamic property deprecations.
- Migration: Run `composer run analyse`.
- Rollback: Remove config + stubs.
- Scope: Added scripts for PHPCS, PHPStan, PHPUnit placeholder.
- Impact: Standardizes contributor commands.
- Migration: `composer install` then run scripts.
- Rollback: Remove scripts section from composer.json.